### PR TITLE
[feat] 필터와 메인 topbar, floating button 구현

### DIFF
--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/login/view/LoginScreen.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/login/view/LoginScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.tico.mypawday.R
+import com.tico.mypawday.ui.theme.MyPawDayDimens
 import com.tico.mypawday.ui.theme.MyPawDayTheme
 
 @Composable
@@ -38,12 +39,7 @@ fun LoginScreen(
             .background(MaterialTheme.colorScheme.background),
     ) {
         val compactHeight = isCompactHeight ?: (maxHeight < 480.dp)
-
-        val contentWidthFraction = when {
-            maxWidth >= 840.dp -> 0.5f
-            maxWidth >= 600.dp -> 0.65f
-            else -> 1f
-        }
+        val loginDimens = MyPawDayDimens.login(maxWidth)
 
         if (compactHeight) {
             LoginScreenLandscape(
@@ -52,7 +48,7 @@ fun LoginScreen(
         } else {
             LoginScreenPortrait(
                 onKakaoLoginClick = onKakaoLoginClick,
-                contentWidthFraction = contentWidthFraction,
+                contentWidthFraction = loginDimens.contentWidthFraction,
             )
         }
     }

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/MainScreen.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/MainScreen.kt
@@ -1,0 +1,99 @@
+package com.tico.mypawday.ui.main.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.tico.mypawday.ui.main.view.component.ExpandableFab
+import com.tico.mypawday.ui.main.view.component.FilterChipsRow
+import com.tico.mypawday.ui.main.view.component.MainTopBar
+import com.tico.mypawday.ui.main.view.model.DiaryType
+import com.tico.mypawday.ui.theme.MyPawDayDimens
+import com.tico.mypawday.ui.theme.MyPawDayTheme
+
+@Composable
+fun MainScreen(
+    modifier: Modifier = Modifier,
+    onMyPageClick: () -> Unit,
+    isCompactHeight: Boolean? = null,
+) {
+    var selectedFilters by remember { mutableStateOf(setOf<DiaryType>()) }
+    var isFabExpanded by remember { mutableStateOf(false) }
+
+    val onFilterToggle: (DiaryType) -> Unit = remember {
+        { type ->
+            selectedFilters = if (type in selectedFilters) {
+                selectedFilters - type
+            } else {
+                selectedFilters + type
+            }
+        }
+    }
+
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        val topBarDimens = MyPawDayDimens.topBar(maxWidth)
+        val fabDimens = MyPawDayDimens.fab(maxWidth)
+        val chipDimens = MyPawDayDimens.filterChip(maxWidth)
+        val contentPadding = MyPawDayDimens.contentPadding(maxWidth)
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    vertical = contentPadding.contentVerticalPadding,
+                    horizontal = contentPadding.contentHorizontalPadding
+                ),
+            verticalArrangement = Arrangement.spacedBy(18.dp)
+        ) {
+            MainTopBar(
+                onMyPageClick = onMyPageClick,
+                myPageIconSize = topBarDimens.myPageIconSize,
+                logoHeight = topBarDimens.logoHeight,
+            )
+
+            FilterChipsRow(
+                selectedFilters = selectedFilters,
+                onFilterToggle = onFilterToggle,
+                dimens = chipDimens,
+            )
+        }
+
+        ExpandableFab(
+            isExpanded = isFabExpanded,
+            onToggle = { isFabExpanded = !isFabExpanded },
+            onWalkClick = { /* TODO: 산책 추가 화면 */ },
+            onHospitalClick = { /* TODO: 병원 추가 화면 */ },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 16.dp, bottom = 24.dp),
+            mainFabSize = fabDimens.mainFabSize,
+            subFabSize = fabDimens.subFabSize,
+            mainIconSize = fabDimens.mainIconSize,
+            subIconSize = fabDimens.subIconSize,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+fun MainScreenLightDarkPreview() {
+    MyPawDayTheme {
+        MainScreen(onMyPageClick = {})
+    }
+}

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/component/ExpandableFab.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/component/ExpandableFab.kt
@@ -1,0 +1,99 @@
+package com.tico.mypawday.ui.main.view.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.tico.mypawday.R
+import com.tico.mypawday.ui.icons.MyPawDayIcons
+
+@Composable
+fun ExpandableFab(
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+    onWalkClick: () -> Unit,
+    onHospitalClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    mainFabSize: Dp,
+    subFabSize: Dp,
+    mainIconSize: Dp,
+    subIconSize: Dp,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        AnimatedVisibility(
+            visible = isExpanded,
+            enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+            exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                FloatingActionButton(
+                    onClick = onWalkClick,
+                    shape = CircleShape,
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    modifier = Modifier.size(subFabSize),
+                ) {
+                    Icon(
+                        imageVector = MyPawDayIcons.IcAddWalk,
+                        contentDescription = stringResource(R.string.content_add_walk),
+                        modifier = Modifier.size(subIconSize),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+
+                FloatingActionButton(
+                    onClick = onHospitalClick,
+                    shape = CircleShape,
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    modifier = Modifier.size(subFabSize),
+                ) {
+                    Icon(
+                        imageVector = MyPawDayIcons.IcAddHospital,
+                        contentDescription = stringResource(R.string.content_add_hospital),
+                        modifier = Modifier.size(subIconSize),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+            }
+        }
+
+        FloatingActionButton(
+            onClick = onToggle,
+            shape = CircleShape,
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            modifier = Modifier.size(mainFabSize),
+        ) {
+            Icon(
+                imageVector = if (isExpanded) {
+                    MyPawDayIcons.IcToggleClose
+                } else {
+                    MyPawDayIcons.IcToggleAdd
+                },
+                contentDescription = if (isExpanded) {
+                    stringResource(R.string.content_fab_close)
+                } else {
+                    stringResource(R.string.content_fab_add)
+                },
+                modifier = Modifier.size(mainIconSize),
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+    }
+}

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/component/FilterChipsRow.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/component/FilterChipsRow.kt
@@ -1,0 +1,124 @@
+package com.tico.mypawday.ui.main.view.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.tico.mypawday.R
+import com.tico.mypawday.ui.icons.MyPawDayIcons
+import com.tico.mypawday.ui.main.view.model.DiaryType
+import com.tico.mypawday.ui.theme.FilterChipDimens
+
+@Composable
+fun FilterChipsRow(
+    selectedFilters: Set<DiaryType>,
+    onFilterToggle: (DiaryType) -> Unit,
+    dimens: FilterChipDimens,
+    modifier: Modifier = Modifier,
+) {
+    val chipShape = CircleShape
+    val chipContentPadding = PaddingValues(
+        horizontal = dimens.horizontalPadding,
+        vertical = dimens.verticalPadding,
+    )
+    val borderColor = MaterialTheme.colorScheme.primaryContainer
+    val containerColor = MaterialTheme.colorScheme.background
+    val selectedContainerColor = MaterialTheme.colorScheme.secondaryContainer
+
+    FlowRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(dimens.spacing),
+        verticalArrangement = Arrangement.spacedBy(dimens.spacing),
+    ) {
+        InputChip(
+            selected = false,
+            onClick = { /* TODO: 펫 필터 바텀시트 */ },
+            label = {
+                Text(
+                    stringResource(R.string.category_pet),
+                    style = dimens.textStyle,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            },
+            trailingIcon = {
+                Icon(
+                    imageVector = MyPawDayIcons.IcArrowDropDown,
+                    contentDescription = null,
+                    modifier = Modifier.size(dimens.dropdownIconSize),
+                )
+            },
+            shape = chipShape,
+            border = InputChipDefaults.inputChipBorder(
+                enabled = true,
+                selected = false,
+                borderColor = borderColor,
+                selectedBorderColor = borderColor,
+            ),
+            colors = InputChipDefaults.inputChipColors(
+                containerColor = containerColor,
+                selectedContainerColor = selectedContainerColor,
+            ),
+            contentPadding = chipContentPadding,
+        )
+
+        FilterChip(
+            selected = DiaryType.WALK in selectedFilters,
+            onClick = { onFilterToggle(DiaryType.WALK) },
+            label = {
+                Text(
+                    stringResource(R.string.category_walk),
+                    style = dimens.textStyle,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            },
+            shape = chipShape,
+            border = FilterChipDefaults.filterChipBorder(
+                enabled = true,
+                selected = DiaryType.WALK in selectedFilters,
+                borderColor = borderColor,
+                selectedBorderColor = borderColor,
+            ),
+            colors = FilterChipDefaults.filterChipColors(
+                containerColor = containerColor,
+                selectedContainerColor = selectedContainerColor,
+            ),
+            contentPadding = chipContentPadding,
+        )
+
+        FilterChip(
+            selected = DiaryType.HOSPITAL in selectedFilters,
+            onClick = { onFilterToggle(DiaryType.HOSPITAL) },
+            label = {
+                Text(
+                    stringResource(R.string.category_hospital),
+                    style = dimens.textStyle,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            },
+            shape = chipShape,
+            border = FilterChipDefaults.filterChipBorder(
+                enabled = true,
+                selected = DiaryType.HOSPITAL in selectedFilters,
+                borderColor = borderColor,
+                selectedBorderColor = borderColor,
+            ),
+            colors = FilterChipDefaults.filterChipColors(
+                containerColor = containerColor,
+                selectedContainerColor = selectedContainerColor,
+            ),
+            contentPadding = chipContentPadding,
+        )
+    }
+}

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/component/MainTopBar.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/component/MainTopBar.kt
@@ -1,0 +1,51 @@
+package com.tico.mypawday.ui.main.view.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Dp
+import com.tico.mypawday.R
+
+@Composable
+fun MainTopBar(
+    onMyPageClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    myPageIconSize: Dp,
+    logoHeight: Dp,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Image(
+            painter = painterResource(R.drawable.ic_banner_horizontal),
+            contentDescription = stringResource(R.string.content_ic_logo_vertical),
+            modifier = Modifier.height(logoHeight),
+            contentScale = ContentScale.Fit,
+        )
+
+        Image(
+            painter = painterResource(R.drawable.ic_mypage),
+            contentDescription = stringResource(R.string.content_ic_mypage),
+            modifier = Modifier
+                .size(myPageIconSize)
+                .clip(CircleShape)
+                .clickable(role = Role.Button, onClick = onMyPageClick),
+            contentScale = ContentScale.Fit,
+        )
+    }
+}

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/splash/view/SplashScreen.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/splash/view/SplashScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.tico.mypawday.R
+import com.tico.mypawday.ui.theme.MyPawDayDimens
 import com.tico.mypawday.ui.theme.MyPawDayTheme
 
 @Composable
@@ -28,16 +29,12 @@ fun SplashScreen(
         contentAlignment = Alignment.Center,
     ) {
         val compactHeight = isCompactHeight ?: (maxHeight < 480.dp)
+        val splashDimens = MyPawDayDimens.splash(maxWidth)
 
         val imageModifier = if (compactHeight) {
-            Modifier.fillMaxHeight(0.7f)
+            Modifier.fillMaxHeight(splashDimens.logoHeightFraction)
         } else {
-            val widthFraction = when {
-                maxWidth >= 840.dp -> 0.35f
-                maxWidth >= 600.dp -> 0.45f
-                else -> 0.65f
-            }
-            Modifier.fillMaxWidth(widthFraction)
+            Modifier.fillMaxWidth(splashDimens.logoWidthFraction)
         }
 
         Image(

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/theme/Dimens.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/theme/Dimens.kt
@@ -1,0 +1,130 @@
+package com.tico.mypawday.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Immutable
+data class TopBarDimens(
+    val myPageIconSize: Dp = 55.dp,
+    val logoHeight: Dp = 55.dp,
+)
+
+@Immutable
+data class FabDimens(
+    val mainFabSize: Dp = 70.dp,
+    val subFabSize: Dp = 48.dp,
+    val mainIconSize: Dp = 36.dp,
+    val subIconSize: Dp = 30.dp,
+)
+
+@Immutable
+data class FilterChipDimens(
+    val textStyle: TextStyle = MyPawDayTypography.robotoRegular14,
+    val spacing: Dp = 8.dp,
+    val dropdownIconSize: Dp = 19.dp,
+    val verticalPadding: Dp = 0.dp,
+    val horizontalPadding: Dp = 10.dp,
+)
+
+@Immutable
+data class ContentPaddingDimens(
+    val contentVerticalPadding: Dp = 18.dp,
+    val contentHorizontalPadding: Dp = 18.dp,
+)
+
+@Immutable
+data class SplashDimens(
+    val logoWidthFraction: Float = 0.65f,
+    val logoHeightFraction: Float = 0.7f,
+)
+
+@Immutable
+data class LoginDimens(
+    val contentWidthFraction: Float = 1f,
+)
+
+object MyPawDayDimens {
+
+    @Composable
+    fun topBar(maxWidth: Dp): TopBarDimens = when {
+        maxWidth >= 840.dp -> TopBarDimens(
+            myPageIconSize = 63.dp,
+            logoHeight = 63.dp,
+        )
+
+        maxWidth >= 600.dp -> TopBarDimens(
+            myPageIconSize = 63.dp,
+            logoHeight = 63.dp,
+        )
+
+        else -> TopBarDimens()
+    }
+
+    @Composable
+    fun fab(maxWidth: Dp): FabDimens = when {
+        maxWidth >= 840.dp -> FabDimens(
+            mainFabSize = 82.dp,
+            subFabSize = 56.dp,
+            mainIconSize = 48.dp,
+            subIconSize = 42.dp,
+        )
+
+        maxWidth >= 600.dp -> FabDimens(
+            mainFabSize = 74.dp,
+            subFabSize = 52.dp,
+            mainIconSize = 44.dp,
+            subIconSize = 38.dp,
+        )
+
+        else -> FabDimens()
+    }
+
+    @Composable
+    fun contentPadding(maxWidth: Dp): ContentPaddingDimens = when {
+        maxWidth >= 840.dp -> ContentPaddingDimens(
+            contentVerticalPadding = 24.dp,
+            contentHorizontalPadding = 24.dp,
+        )
+
+        maxWidth >= 600.dp -> ContentPaddingDimens(
+            contentVerticalPadding = 18.dp,
+            contentHorizontalPadding = 18.dp,
+        )
+
+        else -> ContentPaddingDimens()
+    }
+
+    @Composable
+    fun splash(maxWidth: Dp): SplashDimens = when {
+        maxWidth >= 840.dp -> SplashDimens(logoWidthFraction = 0.35f)
+        maxWidth >= 600.dp -> SplashDimens(logoWidthFraction = 0.45f)
+        else -> SplashDimens()
+    }
+
+    @Composable
+    fun login(maxWidth: Dp): LoginDimens = when {
+        maxWidth >= 840.dp -> LoginDimens(contentWidthFraction = 0.5f)
+        maxWidth >= 600.dp -> LoginDimens(contentWidthFraction = 0.65f)
+        else -> LoginDimens()
+    }
+
+    @Composable
+    fun filterChip(maxWidth: Dp): FilterChipDimens = when {
+        maxWidth >= 840.dp -> FilterChipDimens(
+            textStyle = MyPawDayTypography.robotoRegular16,
+            spacing = 12.dp,
+            dropdownIconSize = 23.dp,
+        )
+
+        maxWidth >= 600.dp -> FilterChipDimens(
+            textStyle = MyPawDayTypography.robotoRegular14,
+            spacing = 10.dp,
+            dropdownIconSize = 21.dp,
+        )
+
+        else -> FilterChipDimens()
+    }
+}

--- a/MyPawDay/app/src/main/res/values/strings.xml
+++ b/MyPawDay/app/src/main/res/values/strings.xml
@@ -1,5 +1,42 @@
 <resources>
     <string name="app_name">MyPawDay</string>
+
+    <!-- Login -->
     <string name="content_kakao_login">카카오 로그인</string>
     <string name="content_ic_logo">멍냥의 하루 로고</string>
+    <string name="content_ic_logo_vertical">멍냥의 하루</string>
+    <string name="content_ic_mypage">내 정보</string>
+
+    <!-- Calendar -->
+    <string name="title_today">오늘</string>
+    <string name="content_previous_month">이전 달</string>
+    <string name="content_next_month">다음 달</string>
+    <string name="content_hospital_indicator">병원</string>
+    <string name="category_sunday">일</string>
+    <string name="category_monday">월</string>
+    <string name="category_tuesday">화</string>
+    <string name="category_wednesday">수</string>
+    <string name="category_thursday">목</string>
+    <string name="category_friday">금</string>
+    <string name="category_saturday">토</string>
+
+    <!-- Filter -->
+    <string name="category_pet">반려동물</string>
+    <string name="category_walk">산책</string>
+    <string name="category_hospital">병원</string>
+
+    <!-- Fab -->
+    <string name="content_add_walk">산책 추가</string>
+    <string name="content_add_hospital">병원 추가</string>
+    <string name="content_fab_close">닫기</string>
+    <string name="content_fab_add">추가</string>
+
+    <!-- Diary Card -->
+    <string name="content_delete">삭제</string>
+    <string name="content_medical_fee">진료비:</string>
+
+    <!-- Delete Dialog -->
+    <string name="title_delete_confirm">삭제 하시겠습니까?</string>
+    <string name="content_cancel">취소</string>
+    <string name="content_delete_action">삭제하기</string>
 </resources>

--- a/MyPawDay/gradle/libs.versions.toml
+++ b/MyPawDay/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.4"
 composeBom = "2026.02.00"
+material3 = "1.5.0-alpha16"
 ksp = "2.0.21-1.0.25"
 hilt = "2.48"
 glide-compose = "2.3.4"
@@ -33,9 +34,9 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-material3-window-size = { module = "androidx.compose.material3:material3-window-size-class" }
-androidx-material3-adaptive-navigation-suite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
+androidx-material3-window-size = { module = "androidx.compose.material3:material3-window-size-class", version.ref = "material3" }
+androidx-material3-adaptive-navigation-suite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite", version.ref = "material3" }
 
 # api 통신을 위한 라이브러리
 retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
- #4
- #6
- #16

<br>

## 📌 개요
- 메인 화면에 사용되는 filter chip과 top bar, floating button을 구현했습니다.

<br>

## 🔁 변경 사항
- material3의 버전 변경
- dimens 설정
- filter chip과 top bar, floating button ui 구현

<br>

## 👀 기타 더 이야기해볼 점
