### PR TITLE
[feat] 반려동물 필터 선택 바텀시트 UI 구현

### DIFF
--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/component/BaseConfirmDialog.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/component/BaseConfirmDialog.kt
@@ -13,8 +13,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.window.Dialog
 import com.tico.mypawday.ui.theme.MyPawDayDimens
 
@@ -26,7 +26,8 @@ fun BaseConfirmDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val density = LocalDensity.current
+    val screenWidth = with(density) { LocalWindowInfo.current.containerSize.width.toDp() }
     val dimens = MyPawDayDimens.dialog(screenWidth)
 
     Dialog(onDismissRequest = onDismiss) {

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/MainScreen.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/MainScreen.kt
@@ -42,9 +42,11 @@ import com.tico.mypawday.ui.main.view.component.DiaryCardItem
 import com.tico.mypawday.ui.main.view.component.ExpandableFab
 import com.tico.mypawday.ui.main.view.component.FilterChipsRow
 import com.tico.mypawday.ui.main.view.component.MainTopBar
+import com.tico.mypawday.ui.main.view.component.PetFilterBottomSheet
 import com.tico.mypawday.ui.main.view.model.CalendarDay
 import com.tico.mypawday.ui.main.view.model.DiaryCard
 import com.tico.mypawday.ui.main.view.model.DiaryType
+import com.tico.mypawday.ui.main.view.model.Pet
 import com.tico.mypawday.ui.theme.FilterChipDimens
 import com.tico.mypawday.ui.theme.MyPawDayDimens
 import com.tico.mypawday.ui.theme.MyPawDayTheme
@@ -66,7 +68,11 @@ fun MainScreen(
     var currentMonth by remember { mutableIntStateOf(today.monthNumber) }
     var selectedDate by remember { mutableStateOf<LocalDate?>(today) }
     var selectedFilters by remember { mutableStateOf(setOf<DiaryType>()) }
+    var selectedPetIds by remember { mutableStateOf(setOf<Long>()) }
+    var showPetFilter by remember { mutableStateOf(false) }
     var isFabExpanded by remember { mutableStateOf(false) }
+
+    val pets = remember { generateDummyPets() }
 
     val calendarDays = remember(currentYear, currentMonth) {
         generateCalendarDays(currentYear, currentMonth).applyDummyData(today)
@@ -74,9 +80,17 @@ fun MainScreen(
 
     var diaryCards by remember { mutableStateOf(generateDummyCards()) }
 
-    val filteredCards = remember(diaryCards, selectedFilters) {
-        if (selectedFilters.isEmpty()) diaryCards
-        else diaryCards.filter { it.type in selectedFilters }
+    val filteredCards = remember(diaryCards, selectedFilters, selectedPetIds, pets) {
+        filterDiaryCards(
+            cards = diaryCards,
+            selectedFilters = selectedFilters,
+            selectedPetIds = selectedPetIds,
+            pets = pets,
+        )
+    }
+
+    val selectedPets = remember(pets, selectedPetIds) {
+        pets.filter { it.id in selectedPetIds }
     }
 
     val onPreviousMonth: () -> Unit = remember(currentYear, currentMonth) {
@@ -120,6 +134,7 @@ fun MainScreen(
             }
         }
     }
+    val onPetFilterClick: () -> Unit = remember { { showPetFilter = true } }
     val onDeleteCard: (DiaryCard) -> Unit = remember {
         { card -> diaryCards = diaryCards.filter { it.id != card.id } }
     }
@@ -145,11 +160,13 @@ fun MainScreen(
                 selectedDate = selectedDate,
                 today = today,
                 selectedFilters = selectedFilters,
+                selectedPets = selectedPets,
                 onPreviousMonth = onPreviousMonth,
                 onNextMonth = onNextMonth,
                 onTodayClick = onTodayClick,
                 onDayClick = onDayClick,
                 onFilterToggle = onFilterToggle,
+                onPetFilterClick = onPetFilterClick,
                 onDeleteCard = onDeleteCard,
                 topBarDimens = topBarDimens,
                 chipDimens = chipDimens,
@@ -165,14 +182,28 @@ fun MainScreen(
                 selectedDate = selectedDate,
                 today = today,
                 selectedFilters = selectedFilters,
+                selectedPets = selectedPets,
                 onPreviousMonth = onPreviousMonth,
                 onNextMonth = onNextMonth,
                 onTodayClick = onTodayClick,
                 onDayClick = onDayClick,
                 onFilterToggle = onFilterToggle,
+                onPetFilterClick = onPetFilterClick,
                 onDeleteCard = onDeleteCard,
                 topBarDimens = topBarDimens,
                 chipDimens = chipDimens,
+            )
+        }
+
+        if (showPetFilter) {
+            PetFilterBottomSheet(
+                pets = pets,
+                selectedPetIds = selectedPetIds,
+                onApply = { ids ->
+                    selectedPetIds = ids
+                    showPetFilter = false
+                },
+                onDismiss = { showPetFilter = false },
             )
         }
 
@@ -202,11 +233,13 @@ private fun MainScreenPortrait(
     selectedDate: LocalDate?,
     today: LocalDate,
     selectedFilters: Set<DiaryType>,
+    selectedPets: List<Pet>,
     onPreviousMonth: () -> Unit,
     onNextMonth: () -> Unit,
     onTodayClick: () -> Unit,
     onDayClick: (CalendarDay) -> Unit,
     onFilterToggle: (DiaryType) -> Unit,
+    onPetFilterClick: () -> Unit,
     onDeleteCard: (DiaryCard) -> Unit,
     topBarDimens: TopBarDimens = TopBarDimens(),
     chipDimens: FilterChipDimens = FilterChipDimens(),
@@ -234,6 +267,8 @@ private fun MainScreenPortrait(
                 selectedFilters = selectedFilters,
                 onFilterToggle = onFilterToggle,
                 dimens = chipDimens,
+                onPetFilterClick = onPetFilterClick,
+                selectedPets = selectedPets,
             )
         }
 
@@ -273,11 +308,13 @@ private fun MainScreenLandscape(
     selectedDate: LocalDate?,
     today: LocalDate,
     selectedFilters: Set<DiaryType>,
+    selectedPets: List<Pet>,
     onPreviousMonth: () -> Unit,
     onNextMonth: () -> Unit,
     onTodayClick: () -> Unit,
     onDayClick: (CalendarDay) -> Unit,
     onFilterToggle: (DiaryType) -> Unit,
+    onPetFilterClick: () -> Unit,
     onDeleteCard: (DiaryCard) -> Unit,
     topBarDimens: TopBarDimens = TopBarDimens(),
     chipDimens: FilterChipDimens = FilterChipDimens(),
@@ -309,9 +346,11 @@ private fun MainScreenLandscape(
             val totalWidthPx = with(density) { maxWidth.toPx() }
 
             Row(modifier = Modifier.fillMaxSize()) {
-                BoxWithConstraints(modifier = Modifier
-                    .weight(splitRatio)
-                    .fillMaxHeight()) {
+                BoxWithConstraints(
+                    modifier = Modifier
+                        .weight(splitRatio)
+                        .fillMaxHeight()
+                ) {
                     val calendarScrollState = rememberScrollState()
                     val calendarCellSize: Dp? = if (fillCalendarHeight) {
                         val weekCount = calendarDays.chunked(7)
@@ -363,6 +402,8 @@ private fun MainScreenLandscape(
                         selectedFilters = selectedFilters,
                         onFilterToggle = onFilterToggle,
                         dimens = chipDimens,
+                        onPetFilterClick = onPetFilterClick,
+                        selectedPets = selectedPets,
                     )
 
                     Spacer(modifier = Modifier.height(8.dp))
@@ -388,6 +429,25 @@ private fun MainScreenLandscape(
                 }
             }
         }
+    }
+}
+
+private fun filterDiaryCards(
+    cards: List<DiaryCard>,
+    selectedFilters: Set<DiaryType>,
+    selectedPetIds: Set<Long>,
+    pets: List<Pet>,
+): List<DiaryCard> {
+    val selectedPetNames = pets
+        .filter { it.id in selectedPetIds }
+        .map { it.name }
+        .toSet()
+
+    return cards.filter { card ->
+        val matchesType = selectedFilters.isEmpty() || card.type in selectedFilters
+        val matchesPet = selectedPetNames.isEmpty() || card.pets.any { it in selectedPetNames }
+
+        matchesType && matchesPet
     }
 }
 

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/MainScreenDummyData.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/MainScreenDummyData.kt
@@ -3,6 +3,7 @@ package com.tico.mypawday.ui.main.view
 import com.tico.mypawday.ui.main.view.model.CalendarDay
 import com.tico.mypawday.ui.main.view.model.DiaryCard
 import com.tico.mypawday.ui.main.view.model.DiaryType
+import com.tico.mypawday.ui.main.view.model.Pet
 import com.tico.mypawday.ui.main.view.model.PetCondition
 import kotlinx.datetime.LocalDate
 
@@ -31,6 +32,15 @@ internal fun isDummyHospitalDay(date: LocalDate, today: LocalDate): Boolean {
     if (date > today) return false
     return date.dayOfMonth % 10 == 3
 }
+
+internal fun generateDummyPets(): List<Pet> = listOf(
+    Pet(id = 1, name = "뽀삐"),
+    Pet(id = 2, name = "코코"),
+    Pet(id = 3, name = "차돌"),
+    Pet(id = 4, name = "초코"),
+    Pet(id = 5, name = "모카"),
+    Pet(id = 6, name = "커피"),
+)
 
 internal fun generateDummyCards(): List<DiaryCard> = listOf(
     DiaryCard(

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/component/FilterChipsRow.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/component/FilterChipsRow.kt
@@ -3,25 +3,30 @@ package com.tico.mypawday.ui.main.view.component
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.InputChip
-import androidx.compose.material3.InputChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.tico.mypawday.R
 import com.tico.mypawday.ui.icons.MyPawDayIcons
 import com.tico.mypawday.ui.main.view.model.DiaryType
+import com.tico.mypawday.ui.main.view.model.Pet
 import com.tico.mypawday.ui.theme.FilterChipDimens
+
+private val PET_CHIP_IMAGE_SIZE = 20.dp
+private val PET_CHIP_OVERLAP_OFFSET = 14.dp
 
 @Composable
 fun FilterChipsRow(
@@ -29,6 +34,8 @@ fun FilterChipsRow(
     onFilterToggle: (DiaryType) -> Unit,
     dimens: FilterChipDimens,
     modifier: Modifier = Modifier,
+    onPetFilterClick: () -> Unit = {},
+    selectedPets: List<Pet> = emptyList(),
 ) {
     val chipShape = CircleShape
     val chipContentPadding = PaddingValues(
@@ -43,36 +50,17 @@ fun FilterChipsRow(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(dimens.spacing),
         verticalArrangement = Arrangement.spacedBy(dimens.spacing),
+        itemVerticalAlignment = Alignment.CenterVertically
     ) {
-        InputChip(
-            selected = false,
-            onClick = { /* TODO: 펫 필터 바텀시트 */ },
-            label = {
-                Text(
-                    stringResource(R.string.category_pet),
-                    style = dimens.textStyle,
-                    color = MaterialTheme.colorScheme.onBackground,
-                )
-            },
-            trailingIcon = {
-                Icon(
-                    imageVector = MyPawDayIcons.IcArrowDropDown,
-                    contentDescription = null,
-                    modifier = Modifier.size(dimens.dropdownIconSize),
-                )
-            },
-            shape = chipShape,
-            border = InputChipDefaults.inputChipBorder(
-                enabled = true,
-                selected = false,
-                borderColor = borderColor,
-                selectedBorderColor = borderColor,
-            ),
-            colors = InputChipDefaults.inputChipColors(
-                containerColor = containerColor,
-                selectedContainerColor = selectedContainerColor,
-            ),
-            contentPadding = chipContentPadding,
+        PetFilterChip(
+            selectedPets = selectedPets,
+            onClick = onPetFilterClick,
+            dimens = dimens,
+            chipShape = chipShape,
+            borderColor = borderColor,
+            containerColor = containerColor,
+            selectedContainerColor = selectedContainerColor,
+            chipContentPadding = chipContentPadding,
         )
 
         DiaryType.entries.forEach { type ->
@@ -86,6 +74,82 @@ fun FilterChipsRow(
                 containerColor = containerColor,
                 selectedContainerColor = selectedContainerColor,
                 chipContentPadding = chipContentPadding,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PetFilterChip(
+    selectedPets: List<Pet>,
+    onClick: () -> Unit,
+    dimens: FilterChipDimens,
+    chipShape: Shape,
+    borderColor: Color,
+    containerColor: Color,
+    selectedContainerColor: Color,
+    chipContentPadding: PaddingValues,
+) {
+    val selected = selectedPets.isNotEmpty()
+    FilterChip(
+        contentPadding = chipContentPadding,
+        onClick = onClick,
+        selected = selected,
+        label = {
+            PetFilterChipLabel(
+                selectedPets = selectedPets,
+                dimens = dimens,
+            )
+        },
+        trailingIcon = {
+            Icon(
+                imageVector = MyPawDayIcons.IcArrowDropDown,
+                contentDescription = null,
+                modifier = Modifier.size(dimens.dropdownIconSize),
+            )
+        },
+        shape = chipShape,
+        border = FilterChipDefaults.filterChipBorder(
+            enabled = true,
+            selected = selected,
+            borderColor = borderColor,
+            selectedBorderColor = borderColor,
+        ),
+        colors = FilterChipDefaults.filterChipColors(
+            containerColor = containerColor,
+            selectedContainerColor = selectedContainerColor,
+        ),
+    )
+}
+
+@Composable
+private fun PetFilterChipLabel(
+    selectedPets: List<Pet>,
+    dimens: FilterChipDimens,
+) {
+    if (selectedPets.isEmpty()) {
+        Text(
+            text = stringResource(R.string.category_pet),
+            style = dimens.textStyle,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        return
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        OverlappingPetImages(
+            pets = selectedPets,
+            imageSize = PET_CHIP_IMAGE_SIZE,
+            overlapOffset = PET_CHIP_OVERLAP_OFFSET,
+        )
+
+        if (selectedPets.size > 3) {
+            Text(
+                text = stringResource(R.string.content_ellipsis),
+                style = dimens.textStyle,
+                color = MaterialTheme.colorScheme.onBackground,
             )
         }
     }

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/component/PetFilterBottomSheet.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/component/PetFilterBottomSheet.kt
@@ -1,0 +1,240 @@
+package com.tico.mypawday.ui.main.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.skydoves.landscapist.ImageOptions
+import com.skydoves.landscapist.glide.GlideImage
+import com.tico.mypawday.R
+import com.tico.mypawday.ui.main.view.model.Pet
+import com.tico.mypawday.ui.theme.MyPawDayDimens
+import com.tico.mypawday.ui.theme.PetFilterSheetDimens
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PetFilterBottomSheet(
+    pets: List<Pet>,
+    selectedPetIds: Set<Long>,
+    onApply: (Set<Long>) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var pendingSelectedIds by remember(selectedPetIds) { mutableStateOf(selectedPetIds) }
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = modifier,
+        containerColor = MaterialTheme.colorScheme.background,
+    ) {
+        BoxWithConstraints {
+            val dimens = MyPawDayDimens.petFilterSheet(maxWidth)
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = dimens.contentHorizontalPadding,
+                        vertical = dimens.contentVerticalPadding,
+                    ),
+                verticalArrangement = Arrangement.spacedBy(dimens.contentVerticalPadding),
+            ) {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(dimens.itemSpacing),
+                    contentPadding = PaddingValues(horizontal = 0.dp),
+                ) {
+                    items(pets, key = { it.id }) { pet ->
+                        PetProfileItem(
+                            pet = pet,
+                            isSelected = pet.id in pendingSelectedIds,
+                            onClick = {
+                                pendingSelectedIds = if (pet.id in pendingSelectedIds) {
+                                    pendingSelectedIds - pet.id
+                                } else {
+                                    pendingSelectedIds + pet.id
+                                }
+                            },
+                            dimens = dimens,
+                        )
+                    }
+                }
+
+                Button(
+                    onClick = { onApply(pendingSelectedIds) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(dimens.buttonHeight),
+                    shape = RoundedCornerShape(dimens.buttonCornerRadius),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                ) {
+                    Text(
+                        text = stringResource(R.string.btn_apply),
+                        style = dimens.petNameStyle,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PetProfileItem(
+    pet: Pet,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    dimens: PetFilterSheetDimens,
+) {
+    Column(
+        modifier = Modifier
+            .width(dimens.petItemWidth)
+            .clip(RoundedCornerShape(dimens.itemCornerRadius))
+            .background(
+                color = if (isSelected) {
+                    MaterialTheme.colorScheme.primaryContainer
+                } else {
+                    Color.Transparent
+                },
+            )
+            .clickable(onClick = onClick)
+            .padding(vertical = dimens.itemVerticalPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(dimens.itemContentSpacing),
+    ) {
+        PetProfileImage(
+            imageUrl = pet.imageUrl,
+            size = dimens.profileImageSize,
+        )
+
+        Text(
+            text = pet.name,
+            style = dimens.petNameStyle,
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+internal fun OverlappingPetImages(
+    pets: List<Pet>,
+    imageSize: Dp,
+    overlapOffset: Dp,
+    borderColor: Color = MaterialTheme.colorScheme.secondaryContainer,
+    shape: Shape = CircleShape,
+) {
+    val displayPets = pets.take(3)
+    Layout(
+        content = {
+            displayPets.forEach { pet ->
+                PetProfileImage(
+                    imageUrl = pet.imageUrl,
+                    size = imageSize,
+                    borderColor = borderColor,
+                    shape = shape,
+                )
+            }
+        },
+    ) { measurables, _ ->
+        val imagePx = imageSize.roundToPx()
+        val overlapPx = overlapOffset.roundToPx()
+        val placeables = measurables.map {
+            it.measure(Constraints.fixed(imagePx, imagePx))
+        }
+        val n = placeables.size
+        val totalWidth = if (n == 0) 0 else imagePx + (n - 1) * overlapPx
+        layout(totalWidth, imagePx) {
+            placeables.forEachIndexed { index, placeable ->
+                placeable.placeRelative(x = index * overlapPx, y = 0)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PetProfileImage(
+    imageUrl: String?,
+    size: Dp,
+    modifier: Modifier = Modifier,
+    borderColor: Color? = null,
+    shape: Shape = CircleShape,
+) {
+    val baseModifier = modifier
+        .size(size)
+        .clip(shape)
+    val imageModifier = baseModifier.withOptionalBorder(
+        borderColor = borderColor,
+        shape = shape,
+    )
+
+    GlideImage(
+        imageModel = { imageUrl },
+        modifier = imageModifier,
+        imageOptions = ImageOptions(contentScale = ContentScale.Crop),
+        failure = {
+            Box(
+                modifier = baseModifier
+                    .background(
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                        shape = shape,
+                    )
+                    .withOptionalBorder(
+                        borderColor = borderColor,
+                        shape = shape,
+                    ),
+            )
+        },
+    )
+}
+
+private fun Modifier.withOptionalBorder(
+    borderColor: Color?,
+    shape: Shape,
+): Modifier {
+    return if (borderColor == null) {
+        this
+    } else {
+        border(width = 1.dp, color = borderColor, shape = shape)
+    }
+}

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/model/MainScreenModels.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/main/view/model/MainScreenModels.kt
@@ -13,6 +13,7 @@ enum class DiaryType {
 data class Pet(
     val id: Long,
     val name: String,
+    val imageUrl: String? = null,
 )
 
 data class CalendarDay(

--- a/MyPawDay/app/src/main/java/com/tico/mypawday/ui/theme/Dimens.kt
+++ b/MyPawDay/app/src/main/java/com/tico/mypawday/ui/theme/Dimens.kt
@@ -25,7 +25,7 @@ data class FilterChipDimens(
     val textStyle: TextStyle = MyPawDayTypography.robotoRegular14,
     val spacing: Dp = 8.dp,
     val dropdownIconSize: Dp = 19.dp,
-    val verticalPadding: Dp = 0.dp,
+    val verticalPadding: Dp = 3.dp,
     val horizontalPadding: Dp = 10.dp,
 )
 
@@ -38,6 +38,21 @@ data class SplashDimens(
 @Immutable
 data class LoginDimens(
     val contentWidthFraction: Float = 1f,
+)
+
+@Immutable
+data class PetFilterSheetDimens(
+    val profileImageSize: Dp = 80.dp,
+    val petItemWidth: Dp = 97.dp,
+    val petNameStyle: TextStyle = MyPawDayTypography.robotoRegular12,
+    val itemCornerRadius: Dp = 12.dp,
+    val itemVerticalPadding: Dp = 10.dp,
+    val itemContentSpacing: Dp = 8.dp,
+    val buttonHeight: Dp = 47.dp,
+    val buttonCornerRadius: Dp = 12.dp,
+    val contentHorizontalPadding: Dp = 18.dp,
+    val contentVerticalPadding: Dp = 20.dp,
+    val itemSpacing: Dp = 5.dp,
 )
 
 @Immutable
@@ -122,6 +137,39 @@ object MyPawDayDimens {
         )
 
         else -> FilterChipDimens()
+    }
+
+    @Composable
+    fun petFilterSheet(maxWidth: Dp): PetFilterSheetDimens = when {
+        maxWidth >= largeTabletMinWidth -> PetFilterSheetDimens(
+            profileImageSize = 112.dp,
+            petItemWidth = 130.dp,
+            petNameStyle = MyPawDayTypography.robotoRegular16,
+            itemCornerRadius = 16.dp,
+            itemVerticalPadding = 14.dp,
+            itemContentSpacing = 12.dp,
+            buttonHeight = 60.dp,
+            buttonCornerRadius = 16.dp,
+            contentHorizontalPadding = 28.dp,
+            contentVerticalPadding = 28.dp,
+            itemSpacing = 9.dp,
+        )
+
+        maxWidth >= tabletMinWidth -> PetFilterSheetDimens(
+            profileImageSize = 96.dp,
+            petItemWidth = 115.dp,
+            petNameStyle = MyPawDayTypography.robotoRegular14,
+            itemCornerRadius = 14.dp,
+            itemVerticalPadding = 12.dp,
+            itemContentSpacing = 10.dp,
+            buttonHeight = 54.dp,
+            buttonCornerRadius = 14.dp,
+            contentHorizontalPadding = 24.dp,
+            contentVerticalPadding = 24.dp,
+            itemSpacing = 7.dp,
+        )
+
+        else -> PetFilterSheetDimens()
     }
 
     @Composable

--- a/MyPawDay/app/src/main/res/values/strings.xml
+++ b/MyPawDay/app/src/main/res/values/strings.xml
@@ -1,6 +1,9 @@
 <resources>
     <string name="app_name">MyPawDay</string>
 
+    <!--Common -->
+    <string name="btn_apply">적용하기</string>
+
     <!-- Login -->
     <string name="content_kakao_login">카카오 로그인</string>
     <string name="content_ic_logo">멍냥의 하루 로고</string>
@@ -39,4 +42,8 @@
     <string name="title_delete_confirm">삭제 하시겠습니까?</string>
     <string name="content_cancel">취소</string>
     <string name="content_delete_action">삭제하기</string>
+
+    <!-- Pet Filter Bottom Sheet -->
+    <string name="content_pet_profile">반려동물 프로필</string>
+    <string name="content_ellipsis">...</string>
 </resources>


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
- #24
- #6
- #4

<br>

## 📌 개요
- 메인 화면에 있는 반려동물 필터 선택에서 사용하는 바텀시트 UI를 구현합니다.

<br>

## 🔁 변경 사항
- PetFilterBottomSheet 컴포넌트 신규 추가
- FilterChipsRow 펫 필터 칩 상태별 디자인 적용
 - 미선택: "반려동물 ▼" 텍스트 칩
 - 1~3마리 선택(choose min): 겹친 원형 프로필 이미지 + 드롭다운 아이콘
 - 4마리 이상(choose more): 3개 겹친 이미지 + "..." + 드롭다운 아이콘
- Pet 모델에 imageUrl: String? 필드 추가
- 관련 string resource 추가
<br>

## 👀 기타 더 이야기해볼 점
